### PR TITLE
Fix to parameters for Bitcoin Minimum Free Priority

### DIFF
--- a/CoinWrapper/CoinParameters/Base/CoinParameters.cs
+++ b/CoinWrapper/CoinParameters/Base/CoinParameters.cs
@@ -47,7 +47,7 @@ namespace BitcoinLib.Services
 
                     FreeTransactionMaximumSizeInBytes = 1000;
                     FreeTransactionMinimumOutputAmountInCoins = 0.01M;
-                    FreeTransactionMinimumPriority = 14400000;
+                    FreeTransactionMinimumPriority = 57600000;
                     FeePerThousandBytesInCoins = 0.0001M;
                     MinimumTransactionFeeInCoins = 0.0001M;
                     MinimumNonDustTransactionAmountInCoins = 0.0000543M;
@@ -78,7 +78,7 @@ namespace BitcoinLib.Services
 
                     FreeTransactionMaximumSizeInBytes = 5000;
                     FreeTransactionMinimumOutputAmountInCoins = 0.001M;
-                    FreeTransactionMinimumPriority = 57600000; //   todo: to be confirmed
+                    FreeTransactionMinimumPriority = 230400000; // see https://github.com/litecoin-project/litecoin/blob/master-0.8/src/main.h#L629
                     FeePerThousandBytesInCoins = 0.001M;
                     MinimumTransactionFeeInCoins = 0.001M;
                     MinimumNonDustTransactionAmountInCoins = 0.001M;


### PR DESCRIPTION
The figure here was based on an earlier commit that did not have the correct value on minimum priority for Bitcoin
