### PR TITLE
GetRawTransactionResponse version

### DIFF
--- a/CoinWrapper/Responses/GetRawTransactionResponse.cs
+++ b/CoinWrapper/Responses/GetRawTransactionResponse.cs
@@ -12,7 +12,7 @@ namespace BitcoinLib.Responses
     {
         public String Hex { get; set; }
         public String TxId { get; set; }
-        public String Version { get; set; }
+        public Int64 Version { get; set; }
         public UInt32 LockTime { get; set; }
         public List<Vin> Vin { get; set; }
         public List<Vout> Vout { get; set; }

--- a/CoinWrapper/Responses/GetRawTransactionResponse.cs
+++ b/CoinWrapper/Responses/GetRawTransactionResponse.cs
@@ -12,7 +12,7 @@ namespace BitcoinLib.Responses
     {
         public String Hex { get; set; }
         public String TxId { get; set; }
-        public UInt32 Version { get; set; }
+        public String Version { get; set; }
         public UInt32 LockTime { get; set; }
         public List<Vin> Vin { get; set; }
         public List<Vout> Vout { get; set; }


### PR DESCRIPTION
Fixes transaction
c659729a7fea5071361c2c1a68551ca2bf77679b27086cc415adeeb03852e369 on
Mainnet.  Version is "-1703168784".  Made string to match
DecodeRawTransactionResponse.