### PR TITLE
Add missing fields and params

### DIFF
--- a/src/BitcoinLib/Responses/GetTransactionResponse.cs
+++ b/src/BitcoinLib/Responses/GetTransactionResponse.cs
@@ -28,6 +28,7 @@ namespace BitcoinLib.Responses
         public string Account { get; set; }
         public string Address { get; set; }
         public decimal Amount { get; set; }
+        public string Label { get; set; }
         public decimal Fee { get; set; }
         public int Vout { get; set; }
         public string Category { get; set; }

--- a/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
@@ -133,7 +133,7 @@ namespace BitcoinLib.Services.RpcServices.RpcService
         bool Move(string fromAccount, string toAccount, decimal amount, int minConf = 1, string comment = "");
         string SendFrom(string fromAccount, string toBitcoinAddress, decimal amount, int minConf = 1, string comment = null, string commentTo = null);
         string SendMany(string fromAccount, Dictionary<string, decimal> toBitcoinAddress, int minConf = 1, string comment = null);
-        string SendToAddress(string bitcoinAddress, decimal amount, string comment = null, string commentTo = null);
+        string SendToAddress(string bitcoinAddress, decimal amount, string comment = null, string commentTo = null, bool subtractFeeFromAmount = false);
         string SetAccount(string bitcoinAddress, string account);
         string SetTxFee(decimal amount);
         string SignMessage(string bitcoinAddress, string message);

--- a/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
@@ -567,7 +567,7 @@ namespace BitcoinLib.Services
                 : _rpcConnector.MakeRequest<string>(RpcMethods.sendrawtransaction, rawTransactionHexString, allowHighFees);
         }
 
-        public string SendToAddress(string bitcoinAddress, decimal amount, string comment, string commentTo)
+        public string SendToAddress(string bitcoinAddress, decimal amount, string comment, string commentTo, bool subtractFeeFromAmount)
         {
             return _rpcConnector.MakeRequest<string>(RpcMethods.sendtoaddress, bitcoinAddress, amount, comment, commentTo);
         }


### PR DESCRIPTION
- Add `Label` field to `GetTransaction`'s response details. (Resolves #34)
- Include `subtractFeeFromAmount` parameter in `SendToAddress` call. (Resolves #38)

/cc @GeorgeKimionis 