### PR TITLE
Submodule Compatibility

### DIFF
--- a/src/BitcoinLib/BitcoinLib.csproj
+++ b/src/BitcoinLib/BitcoinLib.csproj
@@ -7,6 +7,10 @@
     <Copyright>George Kimionis 2014 - 2017</Copyright>
     <Version>1.4.2.0</Version>
     <FileVersion>1.4.2.0</FileVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Institutions may want to customize BitcoinLib at the interface level. This functionality may help to ease the process for sideloading BitcoinLib into the pipeline.

Developers can simply use the submodule command from git's CLI and perform modifications from there and import the library to the other project solutions via Project References.

Signed-off-by: nixxholas <nicholas@slyck.net>