### PR TITLE
Update SigHashType for Bitcoin Cash

### DIFF
--- a/src/BitcoinLib/Requests/SignRawTransaction/SigHashType.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SigHashType.cs
@@ -11,5 +11,11 @@ namespace BitcoinLib.Requests.SignRawTransaction
         public const string AllAnyoneCanPay = "ALL|ANYONECANPAY";
         public const string NoneAnyoneCanPay = "NONE|ANYONECANPAY";
         public const string SingleAnyoneCanPay = "SINGLE|ANYONECANPAY";
+        public const string AllForkId = "ALL|FORKID";
+        public const string NoneForkId = "NONE|FORKID";
+        public const string SingleForkId = "SINGLE|FORKID";
+        public const string ALlForkIdAnyoneCanPay = "ALL|FORKID|ANYONECANPAY";
+        public const string NoneForkIdAnyoneCanPay = "NONE|FORKID|ANYONECANPAY";
+        public const string SingleForkIdAnyoneCanPay = "SINGLE|FORKID|ANYONECANPAY";
     }
 }

--- a/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionRequest.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionRequest.cs
@@ -7,12 +7,12 @@ namespace BitcoinLib.Requests.SignRawTransaction
 {
     public class SignRawTransactionRequest
     {
-        public SignRawTransactionRequest(string rawTransactionHex)
+        public SignRawTransactionRequest(string rawTransactionHex, string sigHashType = "ALL")
         {
             RawTransactionHex = rawTransactionHex;
             Inputs = new List<SignRawTransactionInput>();
             PrivateKeys = new List<string>();
-            SigHashType = SignRawTransaction.SigHashType.All;
+            SigHashType = sigHashType;
         }
 
         public string RawTransactionHex { get; set; }


### PR DESCRIPTION
Add the ability to use BIP143 sighash with SIGHASH_FORKID. Until we do this, the Bitcoin Cash transactions won't be valid.