### PR TITLE
Dallar integration + Fix for "Move" transactions

### DIFF
--- a/demo/App.config
+++ b/demo/App.config
@@ -60,6 +60,14 @@
     <add key="Smartcash_RpcPassword" value="MyRpcPassword" />
     <!-- Smartcash settings end -->
 
+    <!-- Dallar settings start -->
+    <add key="Dallar_DaemonUrl" value="http://localhost:20033" />
+    <add key="Dallar_DaemonUrl_Testnet" value="http://localhost:20133" />
+    <add key="Dallar_WalletPassword" value="MyWalletPassword" />
+    <add key="Dallar_RpcUsername" value="MyRpcUsername" />
+    <add key="Dallar_RpcPassword" value="MyRpcPassword" />
+    <!-- Dallar settings end -->
+
     <!-- Demo client settings start -->
     <add key="ExtractMyPrivateKeys" value="false" />
     <!-- Demo client settings end -->

--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -126,6 +126,12 @@ namespace ConsoleClient
                     Console.WriteLine("\n\nMy transactions' details:");
                     foreach (var transaction in myTransactions)
                     {
+                        // Move transactions don't have a txId, which this logic fails for
+                        if (transaction.Category == "move")
+                        {
+                            continue;
+                        }
+                        
                         var localWalletTransaction = CoinService.GetTransaction(transaction.TxId);
                         IEnumerable<PropertyInfo> localWalletTrasactionProperties = localWalletTransaction.GetType().GetProperties();
                         IList<GetTransactionResponseDetails> localWalletTransactionDetailsList = localWalletTransaction.Details.ToList();

--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -107,7 +107,7 @@ namespace ConsoleClient
                             Console.WriteLine("Other Account: " + transaction.OtherAccount);
                         }
 
-                        if (transaction.WalletConflicts.Any())
+                        if (transaction.WalletConflicts != null && transaction.WalletConflicts.Any())
                         {
                             Console.Write("Conflicted Transactions: ");
 

--- a/src/BitcoinLib/CoinParameters/Base/CoinParameters.cs
+++ b/src/BitcoinLib/CoinParameters/Base/CoinParameters.cs
@@ -8,6 +8,7 @@ using BitcoinLib.Auxiliary;
 using BitcoinLib.Services.Coins.Base;
 using BitcoinLib.Services.Coins.Bitcoin;
 using BitcoinLib.Services.Coins.Cryptocoin;
+using BitcoinLib.Services.Coins.Dallar;
 using BitcoinLib.Services.Coins.Dash;
 using BitcoinLib.Services.Coins.Dogecoin;
 using BitcoinLib.Services.Coins.Litecoin;
@@ -293,6 +294,46 @@ namespace BitcoinLib.Services
                     BlocksHighestPriorityTransactionsReservedSizeInBytes = 50000;
 
                     BaseUnitName = "Smartoshi";
+                    BaseUnitsPerCoin = 100000000;
+                    CoinsPerBaseUnit = 0.00000001M;
+                }
+
+                #endregion
+
+                #region Dallar
+
+                else if (coinService is DallarService)
+                {
+                    if (!IgnoreConfigFiles)
+                    {
+                        DaemonUrl = ConfigurationManager.AppSettings.Get("Dallar_DaemonUrl");
+                        DaemonUrlTestnet = ConfigurationManager.AppSettings.Get("Dallar_DaemonUrl_Testnet");
+                        RpcUsername = ConfigurationManager.AppSettings.Get("Dallar_RpcUsername");
+                        RpcPassword = ConfigurationManager.AppSettings.Get("Dallar_RpcPassword");
+                        WalletPassword = ConfigurationManager.AppSettings.Get("Dallar_WalletPassword");
+                    }
+
+                    CoinShortName = "DAL";
+                    CoinLongName = "Dallar";
+                    IsoCurrencyCode = "DAL";
+
+                    TransactionSizeBytesContributedByEachInput = 148;
+                    TransactionSizeBytesContributedByEachOutput = 34;
+                    TransactionSizeFixedExtraSizeInBytes = 10;
+
+                    FreeTransactionMaximumSizeInBytes = 1000;
+                    FreeTransactionMinimumOutputAmountInCoins = 0.001M;
+                    FreeTransactionMinimumPriority = 230400000;
+                    FeePerThousandBytesInCoins = 0.001M;
+                    MinimumTransactionFeeInCoins = 0.0001M;
+                    MinimumNonDustTransactionAmountInCoins = 0.001M;
+
+                    TotalCoinSupplyInCoins = 80000000;
+                    EstimatedBlockGenerationTimeInMinutes = 1.0;
+                    BlocksHighestPriorityTransactionsReservedSizeInBytes = 16000;
+                    BlockMaximumSizeInBytes = 750000;
+
+                    BaseUnitName = "Allar";
                     BaseUnitsPerCoin = 100000000;
                     CoinsPerBaseUnit = 0.00000001M;
                 }

--- a/src/BitcoinLib/CoinParameters/Dallar/DallarConstants.cs
+++ b/src/BitcoinLib/CoinParameters/Dallar/DallarConstants.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using BitcoinLib.CoinParameters.Base;
+
+namespace BitcoinLib.CoinParameters.Dallar
+{
+    public static class DallarConstants
+    {
+        public sealed class Constants : CoinConstants<Constants>
+        {
+            public readonly ushort CoinReleaseReduceEveryXInBlocks = 10080;
+            public readonly ushort DifficultyIncreasesEveryXInBlocks = 6;
+            public readonly uint OneDallarInAllars = 100000000;
+            public readonly decimal OneAllarInDAL = 0.00000001M;
+            public readonly decimal OneMicroDallarInDAL = 0.000001M;
+            public readonly decimal OneMilliDallarInDAL = 0.001M;
+            public readonly string Symbol = "D";
+        }
+    }
+}

--- a/src/BitcoinLib/CoinParameters/Dallar/IDallarConstants.cs
+++ b/src/BitcoinLib/CoinParameters/Dallar/IDallarConstants.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+namespace BitcoinLib.CoinParameters.Dallar
+{
+    public interface IDallarConstants
+    {
+        DallarConstants.Constants Constants { get; }
+    }
+}

--- a/src/BitcoinLib/Responses/GetFundRawTransactionResponse.cs
+++ b/src/BitcoinLib/Responses/GetFundRawTransactionResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BitcoinLib.Responses
+{
+    public class GetFundRawTransactionResponse
+    {
+        public string Hex { get; set; }
+        public decimal Fee { get; set; }
+        public int ChangePos { get; set; }
+    }
+}

--- a/src/BitcoinLib/Services/Coins/Dallar/DallarService.cs
+++ b/src/BitcoinLib/Services/Coins/Dallar/DallarService.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using BitcoinLib.CoinParameters.Dallar;
+using BitcoinLib.Requests.CreateRawTransaction;
+using BitcoinLib.Responses;
+using BitcoinLib.RPC.Specifications;
+
+namespace BitcoinLib.Services.Coins.Dallar
+{
+    public class DallarService : CoinService, IDallarService
+    {
+        public DallarService(bool useTestnet = false) : base(useTestnet)
+        {
+        }
+
+        public DallarService(string daemonUrl, string rpcUsername, string rpcPassword, string walletPassword = null)
+            : base(daemonUrl, rpcUsername, rpcPassword, walletPassword)
+        {
+        }
+
+        public DallarService(string daemonUrl, string rpcUsername, string rpcPassword, string walletPassword, short rpcRequestTimeoutInSeconds)
+            : base(daemonUrl, rpcUsername, rpcPassword, walletPassword, rpcRequestTimeoutInSeconds)
+        {
+        }
+
+        public DallarConstants.Constants Constants => DallarConstants.Constants.Instance;
+
+        public GetFundRawTransactionResponse GetFundRawTransaction(string rawTransactionHex)
+        {
+            return _rpcConnector.MakeRequest<GetFundRawTransactionResponse>(RpcMethods.fundrawtransaction, rawTransactionHex);
+        }
+
+        public decimal GetEstimateFeeForSendToAddress(string Address, decimal Amount)
+        {
+            var txRequest = new CreateRawTransactionRequest();
+            txRequest.AddOutput(Address, Amount);
+            return GetFundRawTransaction(CreateRawTransaction(txRequest)).Fee;
+        }
+    }
+}

--- a/src/BitcoinLib/Services/Coins/Dallar/IDallarService.cs
+++ b/src/BitcoinLib/Services/Coins/Dallar/IDallarService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using BitcoinLib.CoinParameters.Dallar;
+using BitcoinLib.Responses;
+using BitcoinLib.Services.Coins.Base;
+
+namespace BitcoinLib.Services.Coins.Dallar
+{
+    public interface IDallarService : ICoinService, IDallarConstants
+    {
+        GetFundRawTransactionResponse GetFundRawTransaction(string rawTransactionHex);
+        decimal GetEstimateFeeForSendToAddress(string Address, decimal Amount);
+    }
+}


### PR DESCRIPTION
Added support for the Dallar (http://dallar.org) cryptocurrency.
Fixed "move" transactions crashing the demo app, as they are missing info that is assumed valid in the demo.